### PR TITLE
added rdflib to not depend on global

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.2.17",
       "license": "MIT",
       "dependencies": {
+        "rdflib": "^2.2.19",
         "solid-ui": "^2.4.22"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "homepage": "https://github.com/solid/source-pane",
   "dependencies": {
+    "rdflib": "^2.2.19",
     "solid-ui": "^2.4.22"
   },
   "devDependencies": {

--- a/sourcePane.js
+++ b/sourcePane.js
@@ -3,8 +3,8 @@
  **  This pane allows the original source of a resource to be edited by hand
  **
  */
-/* global alert, $rdf */
 
+const $rdf = require('rdflib')
 const UI = require('solid-ui')
 const mime = require('mime-types')
 


### PR DESCRIPTION
Depending on global makes this repo not useful standalone and it can be that at some point this tight dependency will be forgotten. 